### PR TITLE
Fix ParseException in settings.yaml

### DIFF
--- a/Mailchimp/settings.yaml
+++ b/Mailchimp/settings.yaml
@@ -45,7 +45,7 @@ fields:
       tag:
         type: text
         display: Mailchimp Merge Tag
-        instructions: **Case Matters**! Upper case only please.
+        instructions: "**Case Matters**! Upper case only please."
         width: 50
       field_name:
         type: text
@@ -93,7 +93,7 @@ fields:
           tag:
             type: text
             display: Mailchimp Merge Tag
-            instructions: **Case Matters**! Upper case only please.
+            instructions: "**Case Matters**! Upper case only please."
           field_name:
             type: text
             display: Field Name


### PR DESCRIPTION
Attempting to visit the settings page for this addon throws a ParseException along the following lines:
```
Reference "*Case Matters**! Upper case only please." does not exist at line 3 (near "instructions: **Case Matters**! Upper case only please.").
```
I don't fully understand this error, by my inference is that un-escaped asterisks are some kind of control character for the YAML parser, and they aren't being used in a way it understands. This commit prevents that error.