### PR TITLE
:stars: allow override of email field per formset

### DIFF
--- a/Mailchimp/MailchimpListener.php
+++ b/Mailchimp/MailchimpListener.php
@@ -5,6 +5,7 @@ namespace Statamic\Addons\Mailchimp;
 use Statamic\Extend\Listener;
 use DrewM\MailChimp\MailChimp;
 
+
 class MailchimpListener extends Listener
 {
     /**
@@ -14,7 +15,7 @@ class MailchimpListener extends Listener
      */
     public $events = [
         'user.registered' => 'userRegistration',
-        'Form.submission.created' => 'formSubmission',
+        'Form.submission.created' => 'formSubmission'
     ];
 
     /**
@@ -22,7 +23,8 @@ class MailchimpListener extends Listener
      */
     public function userRegistration($user)
     {
-        if ($this->getConfigBool('add_new_users', false)) {
+        if ($this->getConfigBool('add_new_users', false))
+        {
             $config = [];
             $config['mailchimp_list_id'] = $this->getConfig('user_mailchimp_list_id');
             $config['check_permission'] = $this->getConfigBool('user_check_permission', false);
@@ -30,7 +32,8 @@ class MailchimpListener extends Listener
             $config['disable_opt_in'] = $this->getConfig('user_disable_opt_in');
             $config['merge_fields'] = $this->getConfig('user_merge_fields');
 
-            if ($this->hasPermission($config, $user->data())) {
+            if ($this->hasPermission($config, $user->data()))
+            {
                 $this->subscribe($user->email(), $user, $config);
             }
         }
@@ -47,9 +50,10 @@ class MailchimpListener extends Listener
         $form_config = $this->getFormConfig($formset_name);
 
         // should we process this form and do we have permission to add them to mailchimp?
+        // we'll also default to using email as the fieldname for the submission, if it's null subscribe() will attempt to use the primary_email_field set in the config for the formset.
         if ($this->shouldProcessForm($formset_name) &&
             $this->hasPermission($form_config, $submission->data())) {
-            $this->subscribe($submission->get('email'), $submission, $form_config);
+            $this->subscribe($submission->get('email'), $submission, $form_config );
         }
     }
 
@@ -62,7 +66,8 @@ class MailchimpListener extends Listener
      */
     private function shouldProcessForm($formset_name)
     {
-        return collect($this->getConfig('forms'))->contains(function ($ignore, $value) use ($formset_name) {
+        return collect($this->getConfig('forms'))->contains(function($ignore, $value) use ($formset_name)
+        {
             return $formset_name == array_get($value, 'form');
         });
     }
@@ -100,28 +105,20 @@ class MailchimpListener extends Listener
         $mailchimp_list_id = array_get($config, 'mailchimp_list_id');
 
         $disable_opt_in = array_get($config, 'disable_opt_in', false);
-
+        
         $subscriber_hash = $mailchimp->subscriberHash($email);
 
         $data = [
-            'email_address' => $email,
-            'status' => $disable_opt_in ? 'subscribed' : 'pending',
+            'email_address' => $email ?? $merge_data->get(array_get($config, 'primary_email_field')),
+            'status' => $disable_opt_in ? 'subscribed' : 'pending'
         ];
 
         if ($merge_fields = array_get($config, 'merge_fields')) {
             $data['merge_fields'] = collect($merge_fields)->map(function ($item, $key) use ($merge_data) {
-                // if there ain't nuthin' there, don't send nuthin'
-                if (is_null($fieldData = $merge_data->get($item['field_name']))) {
-                    return [];
-                }
-
-                // convert arrays to strings...Mailchimp don't like no arrays
-                return [
-                    $item['tag'] => is_array($fieldData) ? implode('|', $fieldData) : $fieldData,
-                ];
+                return [$item['tag'] => $merge_data->get($item['field_name'])];
             })->collapse()->all();
         }
-
+        
         $mailchimp->put("lists/{$mailchimp_list_id}/members/{$subscriber_hash}", $data);
 
         if (!$mailchimp->success()) {
@@ -138,7 +135,7 @@ class MailchimpListener extends Listener
      */
     private function getFormConfig($formset_name)
     {
-        return collect($this->getConfig('forms'))->first(function ($ignored, $data) use ($formset_name) {
+        return collect($this->getConfig('forms'))->first(function($ignored, $data) use ($formset_name) {
             return $formset_name == array_get($data, 'form');
         });
     }

--- a/Mailchimp/MailchimpListener.php
+++ b/Mailchimp/MailchimpListener.php
@@ -47,6 +47,7 @@ class MailchimpListener extends Listener
         $form_config = $this->getFormConfig($formset_name);
 
         // should we process this form and do we have permission to add them to mailchimp?
+        // we'll also default to using email as the fieldname for the submission, if it's null subscribe() will attempt to use the primary_email_field set in the config for the formset.
         if ($this->shouldProcessForm($formset_name) &&
             $this->hasPermission($form_config, $submission->data())) {
             $this->subscribe($submission->get('email'), $submission, $form_config);
@@ -104,7 +105,7 @@ class MailchimpListener extends Listener
         $subscriber_hash = $mailchimp->subscriberHash($email);
 
         $data = [
-            'email_address' => $email,
+            'email_address' => $email ?? $merge_data->get(array_get($config, 'primary_email_field')),
             'status' => $disable_opt_in ? 'subscribed' : 'pending',
         ];
 

--- a/Mailchimp/MailchimpListener.php
+++ b/Mailchimp/MailchimpListener.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Addons\Mailchimp;
 
+use Statamic\API\Arr;
 use Statamic\Extend\Listener;
 use DrewM\MailChimp\MailChimp;
 
@@ -64,7 +65,7 @@ class MailchimpListener extends Listener
     private function shouldProcessForm($formset_name)
     {
         return collect($this->getConfig('forms'))->contains(function ($ignore, $value) use ($formset_name) {
-            return $formset_name == array_get($value, 'form');
+            return $formset_name == Arr::get($value, 'form');
         });
     }
 
@@ -78,8 +79,8 @@ class MailchimpListener extends Listener
      */
     private function hasPermission($permissions, $submitted_data)
     {
-        $check_permission = array_get($permissions, 'check_permission', false);
-        $permission_field = array_get($permissions, 'permission_field');
+        $check_permission = Arr::get($permissions, 'check_permission', false);
+        $permission_field = Arr::get($permissions, 'permission_field');
         $have_permission = request()->has($permission_field) ? filter_var(request($permission_field), FILTER_VALIDATE_BOOLEAN) : false;
 
         // if we don't need to check permission we can add OR
@@ -98,18 +99,18 @@ class MailchimpListener extends Listener
     {
         $mailchimp = new MailChimp($this->getConfig('mailchimp_key'));
 
-        $mailchimp_list_id = array_get($config, 'mailchimp_list_id');
+        $mailchimp_list_id = Arr::get($config, 'mailchimp_list_id');
 
-        $disable_opt_in = array_get($config, 'disable_opt_in', false);
+        $disable_opt_in = Arr::get($config, 'disable_opt_in', false);
 
         $subscriber_hash = $mailchimp->subscriberHash($email);
 
         $data = [
-            'email_address' => $email ?? $merge_data->get(array_get($config, 'primary_email_field')),
+            'email_address' => $email ?? $merge_data->get(Arr::get($config, 'primary_email_field')),
             'status' => $disable_opt_in ? 'subscribed' : 'pending',
         ];
 
-        if ($merge_fields = array_get($config, 'merge_fields')) {
+        if ($merge_fields = Arr::get($config, 'merge_fields')) {
             $data['merge_fields'] = collect($merge_fields)->map(function ($item, $key) use ($merge_data) {
                 // if there ain't nuthin' there, don't send nuthin'
                 if (is_null($fieldData = $merge_data->get($item['field_name']))) {
@@ -140,7 +141,7 @@ class MailchimpListener extends Listener
     private function getFormConfig($formset_name)
     {
         return collect($this->getConfig('forms'))->first(function ($ignored, $data) use ($formset_name) {
-            return $formset_name == array_get($data, 'form');
+            return $formset_name == Arr::get($data, 'form');
         });
     }
 }

--- a/Mailchimp/settings.yaml
+++ b/Mailchimp/settings.yaml
@@ -83,7 +83,7 @@ fields:
         type: text
         display: Email Field
         default: email
-        instructions: 'Default's to `email`, but if you use any other field name to capture email, input that here'
+        instructions: 'Defaults to `email`, but if you use any other field name to capture email, input that here'
         width: 50
       permission_field:
         type: mailchimp

--- a/Mailchimp/settings.yaml
+++ b/Mailchimp/settings.yaml
@@ -66,24 +66,30 @@ fields:
         type: text
         display: 'Mailchimp List ID'
         validate: required
-        width: 20
+        width: 50
       disable_opt_in:
         type: toggle
         display: Disable Opt In?
-        width: 20
-      form:
-        type: form
-        max_items: 1
-        width: 20
+        width: 25
       check_permission:
         type: toggle
         display: Check Permission?
-        width: 20
+        width: 25
+      form:
+        type: form
+        max_items: 1
+        width: 50
+      primary_email_field:
+        type: text
+        display: Email Field
+        default: email
+        instructions: 'Default's to `email`, but if you use any other field name to capture email, input that here'
+        width: 50
       permission_field:
         type: mailchimp
         display: ' '
         validate: required
-        width: 20
+        width: 50
         show_when:
           check_permission: true
       merge_fields:


### PR DESCRIPTION
In the event that your form does _not_ use the conventional fieldname of `email` and you'd like to change it to something like `honeypot` for instance - this allows you to set which fieldname the email should be found on that formset. This also cleans up the config layout a smidge to accommodate the new field.

_Also apologize that my linter apparently changed a few lines that have nothing to do with this 😬_
