### PR TITLE
Pass through if configuration info not present

### DIFF
--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -42,7 +42,7 @@ class Subscriber
 
     public function subscribe(): void
     {
-        if (! $this->hasConsent()) {
+        if (! $this->hasConsent() || ! isset($config) ) {
             return;
         }
 


### PR DESCRIPTION
500 error on form submit if this is installed and but not fully configured.